### PR TITLE
Add PHP_Intl extension for use with CiviCRM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,7 @@ RUN set -ex; \
 	soap \
 	xsl \
 	ldap \
+    intl \
 	; \
 	# https://github.com/Imagick/imagick/issues/331
 	# pecl install imagick-3.4.4; \


### PR DESCRIPTION
Added the php_intl extension in so that CiviCRM utilizes it, otherwise CiviCRM causes PHP errors. Might need to add this to PHP 7.4.6 version as well. v4.1.0 tag